### PR TITLE
No full stack trace

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Maven:
 <dependency>
   <groupId>com.wikia</groupId>
   <artifactId>dropwizard-logstash-encoder</artifactId>
-  <version>1.0.1</version>
+  <version>1.1.0</version>
 </dependency>
 ```
 
@@ -29,6 +29,7 @@ Additional configuration keys for the appender, see [logstash-logback-encoder#us
 * `includeMdc` - boolean
 * `customFields` - hashmap - the configuration differs from the original logstash-logback-encoder config in that this is not a raw json string (see example below)
 * `fieldNames` - hashmap
+* `includeFullStackTrace` - bool - if `false`, stack traces are limited to depth of `1`
 * `queueSize` - int - only valid for `logstash-tcp`
 * `includeCallerData` - bool - only valid for `logstash-tcp`
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>com.wikia</groupId>
   <artifactId>dropwizard-logstash-encoder</artifactId>
-  <version>1.0.1</version>
+  <version>1.1.0</version>
   <name>dropwizard-logstash-encoder</name>
   <description>
     Addon for dropwizard to log using the logback-logstash-encoder (see https://github.com/logstash/logstash-logback-encoder)
@@ -81,31 +81,31 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <version>1.5</version>
-        <executions>
-          <execution>
-            <id>sign-artifacts</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>sign</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.3</version>
-        <extensions>true</extensions>
-        <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
-        </configuration>
-      </plugin>
+      <!--<plugin>-->
+        <!--<groupId>org.apache.maven.plugins</groupId>-->
+        <!--<artifactId>maven-gpg-plugin</artifactId>-->
+        <!--<version>1.5</version>-->
+        <!--<executions>-->
+          <!--<execution>-->
+            <!--<id>sign-artifacts</id>-->
+            <!--<phase>verify</phase>-->
+            <!--<goals>-->
+              <!--<goal>sign</goal>-->
+            <!--</goals>-->
+          <!--</execution>-->
+        <!--</executions>-->
+      <!--</plugin>-->
+      <!--<plugin>-->
+        <!--<groupId>org.sonatype.plugins</groupId>-->
+        <!--<artifactId>nexus-staging-maven-plugin</artifactId>-->
+        <!--<version>1.6.3</version>-->
+        <!--<extensions>true</extensions>-->
+        <!--<configuration>-->
+          <!--<serverId>ossrh</serverId>-->
+          <!--<nexusUrl>https://oss.sonatype.org/</nexusUrl>-->
+          <!--<autoReleaseAfterClose>true</autoReleaseAfterClose>-->
+        <!--</configuration>-->
+      <!--</plugin>-->
     </plugins>
   </build>
 
@@ -133,7 +133,7 @@
     <dependency>
       <groupId>net.logstash.logback</groupId>
       <artifactId>logstash-logback-encoder</artifactId>
-      <version>3.5</version>
+      <version>4.3</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -81,33 +81,42 @@
           </execution>
         </executions>
       </plugin>
-      <!--<plugin>-->
-        <!--<groupId>org.apache.maven.plugins</groupId>-->
-        <!--<artifactId>maven-gpg-plugin</artifactId>-->
-        <!--<version>1.5</version>-->
-        <!--<executions>-->
-          <!--<execution>-->
-            <!--<id>sign-artifacts</id>-->
-            <!--<phase>verify</phase>-->
-            <!--<goals>-->
-              <!--<goal>sign</goal>-->
-            <!--</goals>-->
-          <!--</execution>-->
-        <!--</executions>-->
-      <!--</plugin>-->
-      <!--<plugin>-->
-        <!--<groupId>org.sonatype.plugins</groupId>-->
-        <!--<artifactId>nexus-staging-maven-plugin</artifactId>-->
-        <!--<version>1.6.3</version>-->
-        <!--<extensions>true</extensions>-->
-        <!--<configuration>-->
-          <!--<serverId>ossrh</serverId>-->
-          <!--<nexusUrl>https://oss.sonatype.org/</nexusUrl>-->
-          <!--<autoReleaseAfterClose>true</autoReleaseAfterClose>-->
-        <!--</configuration>-->
-      <!--</plugin>-->
     </plugins>
   </build>
+  <profiles>
+    <profile>
+      <id>release</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.5</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>1.6.3</version>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>ossrh</serverId>
+              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <autoReleaseAfterClose>true</autoReleaseAfterClose>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 
   <dependencies>
     <dependency>

--- a/src/main/java/com/wikia/dropwizard/logstash/appender/AbstractLogstashAppenderFactory.java
+++ b/src/main/java/com/wikia/dropwizard/logstash/appender/AbstractLogstashAppenderFactory.java
@@ -2,6 +2,7 @@ package com.wikia.dropwizard.logstash.appender;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import io.dropwizard.logging.AbstractAppenderFactory;
+import net.logstash.logback.stacktrace.ShortenedThrowableConverter;
 
 import javax.validation.constraints.Max;
 import javax.validation.constraints.Min;
@@ -25,6 +26,8 @@ abstract class AbstractLogstashAppenderFactory extends AbstractAppenderFactory {
   protected HashMap<String, String> customFields;
 
   protected HashMap<String, String> fieldNames;
+
+  protected Boolean includeFullStackTrace = true;
 
   @JsonProperty
   public void setHost(String host) {
@@ -95,4 +98,11 @@ abstract class AbstractLogstashAppenderFactory extends AbstractAppenderFactory {
   public void setFieldNames(HashMap<String, String> fieldNames) {
     this.fieldNames = fieldNames;
   }
+
+  @JsonProperty
+  public void setIncludeFullStackTrace(boolean includeFullStackTrace) {
+    this.includeFullStackTrace = includeFullStackTrace;
+  }
+
+
 }

--- a/src/main/java/com/wikia/dropwizard/logstash/appender/AbstractLogstashAppenderFactory.java
+++ b/src/main/java/com/wikia/dropwizard/logstash/appender/AbstractLogstashAppenderFactory.java
@@ -23,11 +23,11 @@ abstract class AbstractLogstashAppenderFactory extends AbstractAppenderFactory {
 
   protected boolean includeMdc = true;
 
+  protected boolean includeFullStackTrace = true;
+
   protected HashMap<String, String> customFields;
 
   protected HashMap<String, String> fieldNames;
-
-  protected Boolean includeFullStackTrace = true;
 
   @JsonProperty
   public void setHost(String host) {
@@ -80,6 +80,11 @@ abstract class AbstractLogstashAppenderFactory extends AbstractAppenderFactory {
   }
 
   @JsonProperty
+  public void setIncludeFullStackTrace(boolean includeFullStackTrace) {
+    this.includeFullStackTrace = includeFullStackTrace;
+  }
+
+  @JsonProperty
   public HashMap<String, String> getCustomFields() {
     return customFields;
   }
@@ -97,11 +102,6 @@ abstract class AbstractLogstashAppenderFactory extends AbstractAppenderFactory {
   @JsonProperty
   public void setFieldNames(HashMap<String, String> fieldNames) {
     this.fieldNames = fieldNames;
-  }
-
-  @JsonProperty
-  public void setIncludeFullStackTrace(boolean includeFullStackTrace) {
-    this.includeFullStackTrace = includeFullStackTrace;
   }
 
 

--- a/src/main/java/com/wikia/dropwizard/logstash/appender/LogstashAppenderFactoryHelper.java
+++ b/src/main/java/com/wikia/dropwizard/logstash/appender/LogstashAppenderFactoryHelper.java
@@ -2,6 +2,7 @@ package com.wikia.dropwizard.logstash.appender;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import net.logstash.logback.fieldnames.LogstashFieldNames;
+import net.logstash.logback.stacktrace.ShortenedThrowableConverter;
 
 import java.io.IOException;
 import java.io.StringWriter;
@@ -36,5 +37,11 @@ public class LogstashAppenderFactoryHelper {
     ObjectMapper mapper = new ObjectMapper();
     mapper.writeValue(writer, map);
     return writer.toString();
+  }
+
+  public static ShortenedThrowableConverter shortStackTraceConverter() {
+    ShortenedThrowableConverter throwableConverter = new ShortenedThrowableConverter();
+    throwableConverter.setMaxDepthPerThrowable(1);
+    return throwableConverter;
   }
 }

--- a/src/main/java/com/wikia/dropwizard/logstash/appender/LogstashSocketAppenderFactory.java
+++ b/src/main/java/com/wikia/dropwizard/logstash/appender/LogstashSocketAppenderFactory.java
@@ -1,5 +1,7 @@
 package com.wikia.dropwizard.logstash.appender;
 
+import static com.wikia.dropwizard.logstash.appender.LogstashAppenderFactoryHelper.shortStackTraceConverter;
+
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
@@ -12,6 +14,7 @@ import java.io.IOException;
 
 @JsonTypeName("logstash-socket")
 public class LogstashSocketAppenderFactory extends AbstractLogstashAppenderFactory {
+
   public LogstashSocketAppenderFactory() {
     port = SyslogConstants.SYSLOG_PORT;
   }
@@ -28,6 +31,10 @@ public class LogstashSocketAppenderFactory extends AbstractLogstashAppenderFacto
     appender.setIncludeCallerInfo(includeCallerInfo);
     appender.setIncludeMdc(includeMdc);
     appender.setIncludeContext(includeContext);
+
+    if (!includeFullStackTrace) {
+      appender.setThrowableConverter(shortStackTraceConverter());
+    }
 
     if (customFields != null) {
       try {
@@ -47,4 +54,5 @@ public class LogstashSocketAppenderFactory extends AbstractLogstashAppenderFacto
 
     return wrapAsync(appender);
   }
+
 }

--- a/src/main/java/com/wikia/dropwizard/logstash/appender/LogstashTcpAppenderFactory.java
+++ b/src/main/java/com/wikia/dropwizard/logstash/appender/LogstashTcpAppenderFactory.java
@@ -1,5 +1,7 @@
 package com.wikia.dropwizard.logstash.appender;
 
+import static com.wikia.dropwizard.logstash.appender.LogstashAppenderFactoryHelper.shortStackTraceConverter;
+
 import ch.qos.logback.classic.LoggerContext;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.Appender;
@@ -59,6 +61,11 @@ public class LogstashTcpAppenderFactory extends AbstractLogstashAppenderFactory 
     encoder.setIncludeContext(includeContext);
     encoder.setIncludeMdc(includeMdc);
     encoder.setIncludeCallerInfo(includeCallerInfo);
+
+    if (!includeFullStackTrace) {
+      encoder.setThrowableConverter(shortStackTraceConverter());
+    }
+
     if (customFields != null) {
       try {
         String custom = LogstashAppenderFactoryHelper.getCustomFieldsFromHashMap(customFields);


### PR DESCRIPTION
Full StackTraces are making the message so big that it's not handled by "intermediate" systems on way to ELK stack (e.g. Syslog) and results in logs not being available in Kibana. By reducing the size of stack trace we can make sure all messages "fit in the pipe".