### PR TITLE
Added Maven profiles for artifact deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,68 @@ LoggerFactory.getLogger("myTestLogger").warn(
 	),
 	"warning! warning!");
 ```
+
+
+## Development
+
+### Deploying Artifacts
+
+#### On Workstation
+
+To make the artifacts available on you local workstation, in `~/.m2/`, execute:
+
+```bash
+$ mvn install
+```
+
+
+#### Local Artifact Repository
+
+Update your Maven settings (`~/.m2/settings.xml`) so that is contains
+`<servers>` and `<profile>`blocks similar to the following.  Replace
+`[USERNAME]`, `[PASSWORD]` and `[REPO_URL]` with the appropriate values.
+
+```xml
+  <servers>
+    <server>
+      <id>local-repo</id>
+      <username>[USERNAME]</username>
+      <password>[PASSWORD]</password>
+    </server>
+  </servers>
+
+  <profiles>
+    <profile>
+      <id>local-repo</id>
+      <properties>
+        <altDeploymentRepository>local-repo::default::[REPO_URL]</altDeploymentRepository>
+      </properties>
+    </profile>
+  </profiles>
+```
+
+The following command will be able to deploy to your Maven artifacts
+repository.
+
+```bash
+$ mvn3 -P local-repo deploy
+```
+
+The [Apache Maven Deploy
+Plugin](http://maven.apache.org/plugins/maven-deploy-plugin/) documentation
+contains more information configuration.
+
+
+#### Sonatype OSS Nexus Repository
+
+This is intended for the maintainers of this project.  Use the `ossrh-deploy`
+Maven profile to deploy the artifacts to [Sonatype's OSS Nexus
+Repository](https://oss.sonatype.org/).
+
+```bash
+$ mvn -P ossrh-deploy clean deploy
+```
+
 ## License
 
 Distributed under the Eclipse Public License either version 1.0 or (at

--- a/pom.xml
+++ b/pom.xml
@@ -33,17 +33,6 @@
     </developer>
   </developers>
 
-  <distributionManagement>
-    <snapshotRepository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-    </snapshotRepository>
-    <repository>
-      <id>ossrh</id>
-      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-    </repository>
-  </distributionManagement>
-
   <build>
     <plugins>
       <plugin>
@@ -81,31 +70,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-gpg-plugin</artifactId>
-        <version>1.5</version>
-        <executions>
-          <execution>
-            <id>sign-artifacts</id>
-            <phase>verify</phase>
-            <goals>
-              <goal>sign</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.sonatype.plugins</groupId>
-        <artifactId>nexus-staging-maven-plugin</artifactId>
-        <version>1.6.3</version>
-        <extensions>true</extensions>
-        <configuration>
-          <serverId>ossrh</serverId>
-          <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-          <autoReleaseAfterClose>true</autoReleaseAfterClose>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 
@@ -136,4 +100,39 @@
       <version>4.7</version>
     </dependency>
   </dependencies>
+
+  <profiles>
+    <profile>
+      <id>ossrh-deploy</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.5</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>1.6.3</version>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>ossrh</serverId>
+              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <autoReleaseAfterClose>true</autoReleaseAfterClose>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Moved artifact deployment to *Sonatype OSS Nexus Repository* into a
Maven profile.  Also added documentation on deploying artifacts.

This change is intended to allow developers to deploy the JARs locally.  The current configuration is hardcoded to deploy to `oss.sonatype.org`, and the version that is in `oss.sonatype.org` is out of date.